### PR TITLE
Update to handle buttons that do not have "OnClick" scripts

### DIFF
--- a/MBB.lua
+++ b/MBB.lua
@@ -735,12 +735,16 @@ function MBB_IsKnownButton(name, opt)
 	return false;
 end
 
+function MBB_HasScript(child)
+	return (child:HasScript("OnClick") or child:HasScript("OnMouseUp"))
+end
+
 function MBB_OnUpdate(elapsed)
 	if( MBB_CheckTime >= 3 ) then
 		MBB_CheckTime = 0;
 		local children = {Minimap:GetChildren()};
 		for _, child in ipairs(children) do
-			if( child:HasScript("OnClick") and not child.oshow and child:GetName() and not MBB_IsKnownButton(child:GetName(), 3) ) then
+			if( MBB_HasScript(child) and not child.oshow and child:GetName() and not MBB_IsKnownButton(child:GetName(), 3) ) then
 				MBB_PrepareButton(child:GetName());
 				if( not MBB_IsInArray(MBB_Exclude, child:GetName()) ) then
 					MBB_AddButton(child:GetName());
@@ -987,9 +991,9 @@ function MBB_NotSureIfThisIsNeeded()
 				end
 			end
 			if( not ignore ) then
-				if( not child:HasScript("OnClick") ) then
+				if( not MBB_HasScript(child) ) then
 					for _,subchild in ipairs({child:GetChildren()}) do
-						if( subchild:HasScript("OnClick") ) then
+						if( MBB_HasScript(subchild) ) then
 							child = subchild;
 							child.hasParentFrame = true;
 							break;


### PR DESCRIPTION
The addon BagSync does not have a "OnClick" event associated with it, but instead has a "OnMouseUp" event, so its button is not seen and consolidated with the other buttons.

This fix is to  have the MBB_OnUpdate function look for both "OnClick" and "OnMouseUp" events.

I created a MBB_HasScript function and call that function in the MBB_OnUpdate and MBB_NotSureIfThisIsNeeded functions.