### PR TITLE
remove Anchor.relativeFrom

### DIFF
--- a/MBB.toc
+++ b/MBB.toc
@@ -1,4 +1,4 @@
-## Interface: 90105
+## Interface: 10000
 ## Author: skunfly (former: karlsnyder, vallantv)
 ## Contributors: CosmicCleric
 ## Version: 4.0.9

--- a/MBB.xml
+++ b/MBB.xml
@@ -214,7 +214,7 @@
 		<Frames>
 			<Slider name="$parent_TimeoutSlider" inherits="OptionsSliderTemplate" minValue="0" maxValue="0">
 				<Anchors>
-					<Anchor relativeFrom="TOPLEFT" point="TOPLEFT" relativeTo="$parent">
+					<Anchor point="TOPLEFT" relativeTo="$parent">
 						<Offset>
 							<AbsDimension x="150" y="-45" />
 						</Offset>
@@ -607,7 +607,7 @@
 					<AbsDimension x="125" y="21" />
 				</Size>
 				<Anchors>
-					<Anchor relativeFrom="TOPLEFT" point="TOP" relativeTo="$parent">
+					<Anchor point="TOP" relativeTo="$parent">
 						<Offset>
 							<AbsDimension x="-75" y="-245" />
 						</Offset>
@@ -647,7 +647,7 @@
 					<AbsDimension x="125" y="21" />
 				</Size>
 				<Anchors>
-					<Anchor relativeFrom="TOPLEFT" point="TOP" relativeTo="$parent">
+					<Anchor point="TOP" relativeTo="$parent">
 						<Offset>
 							<AbsDimension x="75" y="-245" />
 						</Offset>


### PR DESCRIPTION
this is a dragonflight / 10.0 compat change.

I cant see  the attribute even in 9.0.x interface code, so it seems to be technically wrong for a while already, but doesnt currently throw errors on live.

with the property present, a total of 6 errors are thrown on login but it works. this change removes the errors and also already works presently on retail so its save to release already now